### PR TITLE
interfaces/u2f-devices: add Solo V2

### DIFF
--- a/interfaces/builtin/u2f_devices.go
+++ b/interfaces/builtin/u2f_devices.go
@@ -125,7 +125,7 @@ var u2fDevices = []u2fDevice{
 	{
 		Name:             "SoloKeys",
 		VendorIDPattern:  "1209",
-		ProductIDPattern: "5070|50b0",
+		ProductIDPattern: "5070|50b0|beee",
 	},
 	{
 		Name:             "OnlyKey",


### PR DESCRIPTION
Add device ID 1209:BEEE for newly released SoloKeys Solo V2, see

    https://github.com/solokeys/solo2-cli/blob/09a4f8edbd43f5b4ffe7e715e05143b9fc815535/README.md

This is needed for my new security key to work with snap-packaged Firefox.